### PR TITLE
Refactoring receive package

### DIFF
--- a/packages/receive/src/buffer.ts
+++ b/packages/receive/src/buffer.ts
@@ -22,7 +22,7 @@ export const parseBody = ({
     , length
     , encoding
 })
-    .then((rawBody) => {
+    .then((rawBody: Buffer | string) => {
         rawBodyCache.set(context.req, rawBody)
         return rawBody
     })

--- a/packages/receive/src/buffer.ts
+++ b/packages/receive/src/buffer.ts
@@ -17,7 +17,7 @@ export const parseBody = ({
     , length
     , encoding
     , rawBodyCache
-}: ParseBody) => getRawBody(context.req, {
+}: ParseBody): Promise<Buffer | string> => getRawBody(context.req, {
     limit
     , length
     , encoding

--- a/packages/receive/src/index.ts
+++ b/packages/receive/src/index.ts
@@ -18,8 +18,8 @@ export const text = (context: Context, options?: GetRawBodyOptions) => stringOrB
 
 export const createReceive = (context: Context): Receive => {
     return {
-        json: <T>(options?: GetRawBodyOptions) => json<T>(context, options)
-        , text: (options?: GetRawBodyOptions) => text(context, options)
+        text: (options?: GetRawBodyOptions) => text(context, options)
+        , json: <T>(options?: GetRawBodyOptions) => json<T>(context, options)
         , buffer: (options?: GetRawBodyOptions) => buffer(context, options)
     }
 }

--- a/packages/receive/src/index.ts
+++ b/packages/receive/src/index.ts
@@ -1,42 +1,14 @@
 import { IncomingMessage } from 'http'
 import { Context, Receive } from 'wezi-types'
 import { parseJSON } from './utils'
-import { parseBody } from './buffer'
-import { Options as GetRawBodyOptions, Encoding as GetRawBodyEncoding } from 'raw-body'
+import { parseBody, getRawBodyBuffer, RawBodyCacheMapBuffer } from './buffer'
+import { Options as GetRawBodyOptions } from 'raw-body'
 import contentType from 'content-type'
-import createError from 'wezi-error'
 
 type CacheJsonMap = WeakMap<IncomingMessage, unknown>
 type RawBodyCacheMapString = WeakMap<IncomingMessage, string>
-type RawBodyCacheMapBuffer = WeakMap<IncomingMessage, Buffer>
 
-type ParseBufferArgs = {
-    context: Context
-    limit: string | number
-    length: string
-    encoding: GetRawBodyEncoding
-    rawBodyCache: RawBodyCacheMapBuffer
-}
-
-const getRawBodyBuffer = async ({
-    context
-    , limit
-    , length
-    , encoding
-    , rawBodyCache
-}: ParseBufferArgs): Promise<Buffer> => {
-    const body = await parseBody({
-        context
-        , limit
-        , length
-        , encoding
-        , rawBodyCache
-    })
-
-    if (Buffer.isBuffer(body)) return body
-    throw createError(500, 'Body must be typeof Buffer')
-}
-
+const defaultBodySizeLimit = '1mb'
 const stringOrBuffer = toStringOrBuffer()
 
 export const json = toJson()
@@ -55,7 +27,7 @@ export const createReceive = (context: Context): Receive => {
 export function toStringOrBuffer() {
     // avoid to read multiple times same stream object
     const rawBodyCache: RawBodyCacheMapString = new WeakMap()
-    return (context: Context, { limit = '1mb', encoding }: GetRawBodyOptions = {}): Promise<Buffer | string> => {
+    return (context: Context, { limit = defaultBodySizeLimit, encoding }: GetRawBodyOptions = {}): Promise<Buffer | string> => {
         const body = rawBodyCache.get(context.req)
         const type = context.req.headers['content-type'] ?? 'text/plain'
         const length = context.req.headers['content-length']
@@ -85,7 +57,7 @@ export function toStringOrBuffer() {
 export function toBuffer() {
     // avoid to read multiple times same stream object
     const rawBodyCache: RawBodyCacheMapBuffer = new WeakMap()
-    return (context: Context, { limit = '1mb', encoding }: GetRawBodyOptions = {}): Promise<Buffer> => {
+    return (context: Context, { limit = defaultBodySizeLimit, encoding }: GetRawBodyOptions = {}): Promise<Buffer> => {
         const body = rawBodyCache.get(context.req)
         const type = context.req.headers['content-type'] ?? 'application/octet-stream'
         const length = context.req.headers['content-length']

--- a/packages/types/src/receive.ts
+++ b/packages/types/src/receive.ts
@@ -3,5 +3,5 @@ import { Options as GetRawBodyOptions } from 'raw-body'
 export interface Receive {
     json: <T>(options?: GetRawBodyOptions) => Promise<T>
     text: (options?: GetRawBodyOptions) => Promise<string>
-    buffer: (options?: GetRawBodyOptions) => Promise<Buffer>
+    buffer: (options?: GetRawBodyOptions) => Promise<Buffer | null>
 }

--- a/packages/types/src/receive.ts
+++ b/packages/types/src/receive.ts
@@ -3,5 +3,5 @@ import { Options as GetRawBodyOptions } from 'raw-body'
 export interface Receive {
     json: <T>(options?: GetRawBodyOptions) => Promise<T>
     text: (options?: GetRawBodyOptions) => Promise<string>
-    buffer: (options?: GetRawBodyOptions) => Promise<string>
+    buffer: (options?: GetRawBodyOptions) => Promise<Buffer>
 }

--- a/packages/types/src/receive.ts
+++ b/packages/types/src/receive.ts
@@ -1,7 +1,7 @@
 import { Options as GetRawBodyOptions } from 'raw-body'
 
 export interface Receive {
-    json: <T>(options?: GetRawBodyOptions) => Promise<T>
     text: (options?: GetRawBodyOptions) => Promise<string>
+    json: <T>(options?: GetRawBodyOptions) => Promise<T>
     buffer: (options?: GetRawBodyOptions) => Promise<Buffer | null>
 }

--- a/tests/receive.test.ts
+++ b/tests/receive.test.ts
@@ -61,11 +61,25 @@ test('receive buffer', async (t) => {
 
     const res = await fetch(url, {
         method: 'POST'
-        , body: '🐻'
+        , body: Buffer.from('🐻')
     })
 
     const body = await res.text()
     t.is(body, '🐻')
+})
+
+test('receive non buffer', async (t) => {
+    const fn = async (c: Context) => {
+        const err = await t.throwsAsync(() => buffer(c))
+        t.is(err.message, 'Body must be typeof Buffer')
+        return err
+    }
+    const url = await server(fn)
+    const res = await fetch(url, {
+        method: 'POST'
+        , body: '🐻'
+    })
+    t.is(res.status, 500)
 })
 
 test('receive text', async (t) => {

--- a/tests/wezi.test.ts
+++ b/tests/wezi.test.ts
@@ -68,7 +68,7 @@ test('context receive buffer', async (t) => {
 
     const res = await fetch(url, {
         method: 'POST'
-        , body: '🐻'
+        , body: Buffer.from('🐻')
     })
 
     const body = await res.text()


### PR DESCRIPTION
The raw body library can interpret and return values of type Buffers or Strings.

the function receive.buffer, it was not strictly verified that the raw body received in the query was of type Buffer, also on some occasions it was converted to a string, due to a bad logic approach.

This pull request will fix these problems.