### PR TITLE
Refactoring receive package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "lerna": "^3.22.1",
-    "nyc": "^15.1.0",
     "node-fetch": "^2.6.1",
+    "nyc": "^15.1.0",
     "test-listen": "^1.1.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"

--- a/packages/receive/package.json
+++ b/packages/receive/package.json
@@ -22,6 +22,7 @@
     "wezi-types": "^1.0.0-alpha.13"
   },
   "devDependencies": {
+    "@types/content-type": "^1.1.3",
     "@types/node": "^14.14.10",
     "typescript": "^4.0.3"
   }

--- a/packages/receive/src/buffer.ts
+++ b/packages/receive/src/buffer.ts
@@ -19,24 +19,8 @@ type ParseBufferOptions = {
     rawBodyCache: WeakMap<IncomingMessage, Buffer>
 }
 
-export const getRawBodyBuffer = async ({
-    context
-    , limit
-    , length
-    , encoding
-    , rawBodyCache
-}: ParseBufferOptions): Promise<Buffer> => {
-    const body = await getRawBody({
-        context
-        , limit
-        , length
-        , encoding
-        , rawBodyCache
-    })
-
-    if (Buffer.isBuffer(body)) return body
-    throw createError(500, 'Body must be typeof Buffer')
-}
+// raw body return a string encoded when charset param is defined in the Content-type header or when encoding option is passed.
+const forceToBuffer = (body: string | Buffer) => Buffer.isBuffer(body) ? body : Buffer.from(body)
 
 export const getRawBody = ({
     context
@@ -60,3 +44,20 @@ export const getRawBody = ({
         throw createError(400, 'Invalid body', err)
     })
 
+export const getRawBodyBuffer = async ({
+    context
+    , limit
+    , length
+    , encoding
+    , rawBodyCache
+}: ParseBufferOptions): Promise<Buffer> => {
+    const body = await getRawBody({
+        context
+        , limit
+        , length
+        , encoding
+        , rawBodyCache
+    })
+
+    return forceToBuffer(body)
+}

--- a/packages/receive/src/index.ts
+++ b/packages/receive/src/index.ts
@@ -25,7 +25,7 @@ type GetRawBodyFunctionOptions<T> = {
     rawBodyCache: WeakMap<IncomingMessage, T>
 }
 
-const resolveRawBody = <T> (fn: GetRawBodyFunction<T>, {
+const resolveRawBody = <T>(fn: GetRawBodyFunction<T>, {
     context
     , limit
     , encoding
@@ -38,8 +38,8 @@ const resolveRawBody = <T> (fn: GetRawBodyFunction<T>, {
 
     if (body) return Promise.resolve(body)
     if (encoding === undefined) {
-        const parameters = contentType.parse(type)?.parameters
-        const charset = parameters?.charset
+        const { parameters } = contentType.parse(type)
+        const charset = parameters.charset
         return fn({
             context
             , limit

--- a/packages/wezi/package.json
+++ b/packages/wezi/package.json
@@ -25,9 +25,5 @@
     "wezi-receive": "^1.0.0-alpha.13",
     "wezi-send": "^1.0.0-alpha.13",
     "wezi-types": "^1.0.0-alpha.13"
-  },
-  "devDependencies": {
-    "@types/node": "^14.14.10",
-    "typescript": "^4.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/content-type@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/content-type/-/content-type-1.1.3.tgz#3688bd77fc12f935548eef102a4e34c512b03a07"
+  integrity sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"


### PR DESCRIPTION
Are fixed a raw body parser return whit encoding. When encoding are detected in the content type of the header, raw Body parser returned a string. The function buffer must be strict and allways return an  Buffer type value.