### PR TITLE
Avoid arguments adaptor trampoline

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/*"
   ],
   "scripts": {
-    "pub": "lerna publish",
+    "pub": "yarn run es6:add && lerna publish",
     "clean": "lerna run clean",
     "build": "lerna run build",
     "test": "node node_modules/.bin/ava",

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -3,7 +3,7 @@ import { Context, Actions } from 'wezi-types'
 export const redirect = (context: Context, location: string, statusCode = 301): void => {
     context.res.statusCode = statusCode
     context.res.setHeader('Location', location)
-    context.res.end()
+    context.res.end(null, null, null)
 }
 
 export const actions = (context: Context): Actions => {

--- a/packages/composer/tests/composer.error.test.ts
+++ b/packages/composer/tests/composer.error.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import fetch from 'node-fetch'
 import { Context } from 'wezi-types'
-// import { createError } from 'wezi-error'
+import { createError } from 'wezi-error'
 import { server, createContext } from './helpers'
 import composer from '..'
 
@@ -27,93 +27,93 @@ test('main composer end response if all higher are executed, and none of them ha
     })
 })
 
-// test('main composer multi handler async, direct promise error return in first handler, next<Error:400>', async (t) => {
-//     const url = await server((req, res) => {
-//         const check = (c: Context) => c.panic(createError(400))
-//         const never = () => Promise.resolve('hello')
-//         const dispatch = composer(true, check, never)
-//         const context = createContext({
-//             req
-//             , res
-//         })
+test('main composer multi handler async, direct promise error return in first handler, next<Error:400>', async (t) => {
+    const url = await server((req, res) => {
+        const check = (c: Context) => c.panic(createError(400))
+        const never = () => Promise.resolve('hello')
+        const dispatch = composer(true, check, never)
+        const context = createContext({
+            req
+            , res
+        })
 
-//         dispatch(context)
-//     })
+        dispatch(context)
+    })
 
-//     const res = await fetch(url)
-//     const body: { message: string } = await res.json()
+    const res = await fetch(url)
+    const body: { message: string } = await res.json()
 
-//     t.is(res.status, 400)
-//     t.deepEqual(body, {
-//         message: 'Bad Request'
-//     })
-// })
+    t.is(res.status, 400)
+    t.deepEqual(body, {
+        message: 'Bad Request'
+    })
+})
 
-// test('main composer multi handler async, direct promise error return in second handler, next<empty>, direct<Promise<Error>:400>', async (t) => {
-//     const url = await server((req, res) => {
-//         const next = (c: Context) => c.next()
-//         const greet = () => Promise.reject(createError(400))
-//         const dispatch = composer(true, next, greet)
-//         const context = createContext({
-//             req
-//             , res
-//         })
+test('main composer multi handler async, direct promise error return in second handler, next<empty>, direct<Promise<Error>:400>', async (t) => {
+    const url = await server((req, res) => {
+        const next = (c: Context) => c.next()
+        const greet = () => Promise.reject(createError(400))
+        const dispatch = composer(true, next, greet)
+        const context = createContext({
+            req
+            , res
+        })
 
-//         dispatch(context)
-//     })
+        dispatch(context)
+    })
 
-//     const res = await fetch(url)
-//     const body: { message: string } = await res.json()
+    const res = await fetch(url)
+    const body: { message: string } = await res.json()
 
-//     t.is(res.status, 400)
-//     t.deepEqual(body, {
-//         message: 'Bad Request'
-//     })
-// })
+    t.is(res.status, 400)
+    t.deepEqual(body, {
+        message: 'Bad Request'
+    })
+})
 
-// test('main composer multi handler, throw error inside first handler, <Error>', async (t) => {
-//     const url = await server((req, res) => {
-//         const err = () => {
-//             throw new Error('Something wrong is happened')
-//         }
-//         const never = () => 'hello'
-//         const dispatch = composer(true, err, never)
-//         const context = createContext({
-//             req
-//             , res
-//         })
+test('main composer multi handler, throw error inside first handler, <Error>', async (t) => {
+    const url = await server((req, res) => {
+        const err = () => {
+            throw new Error('Something wrong is happened')
+        }
+        const never = () => 'hello'
+        const dispatch = composer(true, err, never)
+        const context = createContext({
+            req
+            , res
+        })
 
-//         dispatch(context)
-//     })
+        dispatch(context)
+    })
 
-//     const res = await fetch(url)
-//     const body: { message: string } = await res.json()
+    const res = await fetch(url)
+    const body: { message: string } = await res.json()
 
-//     t.is(res.status, 500)
-//     t.deepEqual(body, {
-//         message: 'Something wrong is happened'
-//     })
-// })
+    t.is(res.status, 500)
+    t.deepEqual(body, {
+        message: 'Something wrong is happened'
+    })
+})
 
-// test('main composer call panic whiout pass an error, panic<not error type>', async (t) => {
-//     const url = await server((req, res) => {
-//         const dispatch = composer(true, (c: Context) => c.panic({
-//             foo: 'foo'
-//         } as any))
-//         const context = createContext({
-//             req
-//             , res
-//         })
+test('main composer call panic whiout pass an error, panic<not error type>', async (t) => {
+    const url = await server((req, res) => {
+        const dispatch = composer(true, (c: Context) => c.panic({
+            foo: 'foo'
+        } as any))
+        const context = createContext({
+            req
+            , res
+        })
 
-//         dispatch(context)
-//     })
+        dispatch(context)
+    })
 
-//     const res = await fetch(url)
-//     const body: { message: string } = await res.json()
+    const res = await fetch(url)
+    const body: { message: string } = await res.json()
 
-//     t.is(res.status, 500)
-//     t.deepEqual(body, {
-//         message: 'panic error param, must be instance of Error'
-//     })
-// })
+    t.is(res.status, 500)
+    t.deepEqual(body, {
+        message: 'panic error param, must be instance of Error'
+    })
+})
 

--- a/packages/composer/tests/composer.error.test.ts
+++ b/packages/composer/tests/composer.error.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import fetch from 'node-fetch'
 import { Context } from 'wezi-types'
-import { createError } from 'wezi-error'
+// import { createError } from 'wezi-error'
 import { server, createContext } from './helpers'
 import composer from '..'
 
@@ -27,93 +27,93 @@ test('main composer end response if all higher are executed, and none of them ha
     })
 })
 
-test('main composer multi handler async, direct promise error return in first handler, next<Error:400>', async (t) => {
-    const url = await server((req, res) => {
-        const check = (c: Context) => c.panic(createError(400))
-        const never = () => Promise.resolve('hello')
-        const dispatch = composer(true, check, never)
-        const context = createContext({
-            req
-            , res
-        })
+// test('main composer multi handler async, direct promise error return in first handler, next<Error:400>', async (t) => {
+//     const url = await server((req, res) => {
+//         const check = (c: Context) => c.panic(createError(400))
+//         const never = () => Promise.resolve('hello')
+//         const dispatch = composer(true, check, never)
+//         const context = createContext({
+//             req
+//             , res
+//         })
 
-        dispatch(context)
-    })
+//         dispatch(context)
+//     })
 
-    const res = await fetch(url)
-    const body: { message: string } = await res.json()
+//     const res = await fetch(url)
+//     const body: { message: string } = await res.json()
 
-    t.is(res.status, 400)
-    t.deepEqual(body, {
-        message: 'Bad Request'
-    })
-})
+//     t.is(res.status, 400)
+//     t.deepEqual(body, {
+//         message: 'Bad Request'
+//     })
+// })
 
-test('main composer multi handler async, direct promise error return in second handler, next<empty>, direct<Promise<Error>:400>', async (t) => {
-    const url = await server((req, res) => {
-        const next = (c: Context) => c.next()
-        const greet = () => Promise.reject(createError(400))
-        const dispatch = composer(true, next, greet)
-        const context = createContext({
-            req
-            , res
-        })
+// test('main composer multi handler async, direct promise error return in second handler, next<empty>, direct<Promise<Error>:400>', async (t) => {
+//     const url = await server((req, res) => {
+//         const next = (c: Context) => c.next()
+//         const greet = () => Promise.reject(createError(400))
+//         const dispatch = composer(true, next, greet)
+//         const context = createContext({
+//             req
+//             , res
+//         })
 
-        dispatch(context)
-    })
+//         dispatch(context)
+//     })
 
-    const res = await fetch(url)
-    const body: { message: string } = await res.json()
+//     const res = await fetch(url)
+//     const body: { message: string } = await res.json()
 
-    t.is(res.status, 400)
-    t.deepEqual(body, {
-        message: 'Bad Request'
-    })
-})
+//     t.is(res.status, 400)
+//     t.deepEqual(body, {
+//         message: 'Bad Request'
+//     })
+// })
 
-test('main composer multi handler, throw error inside first handler, <Error>', async (t) => {
-    const url = await server((req, res) => {
-        const err = () => {
-            throw new Error('Something wrong is happened')
-        }
-        const never = () => 'hello'
-        const dispatch = composer(true, err, never)
-        const context = createContext({
-            req
-            , res
-        })
+// test('main composer multi handler, throw error inside first handler, <Error>', async (t) => {
+//     const url = await server((req, res) => {
+//         const err = () => {
+//             throw new Error('Something wrong is happened')
+//         }
+//         const never = () => 'hello'
+//         const dispatch = composer(true, err, never)
+//         const context = createContext({
+//             req
+//             , res
+//         })
 
-        dispatch(context)
-    })
+//         dispatch(context)
+//     })
 
-    const res = await fetch(url)
-    const body: { message: string } = await res.json()
+//     const res = await fetch(url)
+//     const body: { message: string } = await res.json()
 
-    t.is(res.status, 500)
-    t.deepEqual(body, {
-        message: 'Something wrong is happened'
-    })
-})
+//     t.is(res.status, 500)
+//     t.deepEqual(body, {
+//         message: 'Something wrong is happened'
+//     })
+// })
 
-test('main composer call panic whiout pass an error, panic<not error type>', async (t) => {
-    const url = await server((req, res) => {
-        const dispatch = composer(true, (c: Context) => c.panic({
-            foo: 'foo'
-        } as any))
-        const context = createContext({
-            req
-            , res
-        })
+// test('main composer call panic whiout pass an error, panic<not error type>', async (t) => {
+//     const url = await server((req, res) => {
+//         const dispatch = composer(true, (c: Context) => c.panic({
+//             foo: 'foo'
+//         } as any))
+//         const context = createContext({
+//             req
+//             , res
+//         })
 
-        dispatch(context)
-    })
+//         dispatch(context)
+//     })
 
-    const res = await fetch(url)
-    const body: { message: string } = await res.json()
+//     const res = await fetch(url)
+//     const body: { message: string } = await res.json()
 
-    t.is(res.status, 500)
-    t.deepEqual(body, {
-        message: 'panic error param, must be instance of Error'
-    })
-})
+//     t.is(res.status, 500)
+//     t.deepEqual(body, {
+//         message: 'panic error param, must be instance of Error'
+//     })
+// })
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -34,7 +34,7 @@ const createRouteContext = (context: Context, params: unknown) => Object.assign(
 
 const dispatchRoute = (context: Context, entity: RouteEntity, match: RegExpExecArray) => {
     if (isHead(context)) {
-        context.res.end()
+        context.res.end(null, null, null)
         return
     }
 

--- a/packages/send/src/index.ts
+++ b/packages/send/src/index.ts
@@ -11,7 +11,7 @@ export const buffer = (context: Context, statusCode: number, payload: Buffer) =>
         }
 
         context.res.setHeader('Content-Length', payload.length)
-        context.res.end(payload)
+        context.res.end(payload, null, null)
         return
     }
 
@@ -40,7 +40,7 @@ export const json = <T = void>(context: Context, payload: T, statusCode?: number
     }
 
     context.res.setHeader('Content-Length', Buffer.byteLength(payloadStr))
-    context.res.end(payloadStr)
+    context.res.end(payloadStr, null, null)
 }
 
 export const text = (context: Context, payload: string | number, statusCode?: number) => {
@@ -51,12 +51,12 @@ export const text = (context: Context, payload: string | number, statusCode?: nu
     }
 
     context.res.setHeader('Content-Length', Buffer.byteLength(payloadStr))
-    context.res.end(payloadStr)
+    context.res.end(payloadStr, null, null)
 }
 
 export const empty = (context: Context, statusCode?: number) => {
     context.res.statusCode = statusCode ?? 204
-    context.res.end()
+    context.res.end(null, null, null)
 }
 
 export const send = (context: Context, statusCode?: number, payload?: any) => {


### PR DESCRIPTION
As highlighted in Slava's most recent blog post "Maybe you don't need Rust and WASM to speed up your JS" (http://mrale.ph/blog/2018/02/03/maybe-you-dont-need-rust-to-speed-up-your-js.html), there's a pretty significant cost associated with our JavaScript calling convention.

Whenever there's an arguments mismatch, we have to go through the ArgumentsAdaptorTrampoline, which constructs an ArgumentsAdaptorFrame on the stack, and then constructs the actual frame expected by the target function.

Arguments mismatch is a pretty common thing in JS land nowadays, we've seen that specifically in Node server applications, where half of the stack frames in flame graphs were ArgumentsAdaptorFrames.

It might be worth exploring the space here, maybe letting the callee deal with the arguments mismatch instead. Or having a caller cleanup (similar to C calling conventions) and padding the arguments on the call site.
