### PR TITLE
feat: add function to send response only whit status code and msg

### DIFF
--- a/packages/composer/tests/helpers/index.ts
+++ b/packages/composer/tests/helpers/index.ts
@@ -13,6 +13,7 @@ export const createContext = ({
     , next = null
     , panic = null
     , shared = null
+    , empty = null
     , status = null
     , actions = null
 }): Context => ({
@@ -22,6 +23,7 @@ export const createContext = ({
     , next
     , panic
     , shared
+    , empty
     , status
     , actions
 })

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,7 @@ export interface Context<T = any> {
     readonly body: Body
     readonly next: Next
     readonly panic: Panic
+    readonly empty: Empty
     readonly status: Status
     readonly shared: Shared<T>
     readonly actions: Actions
@@ -26,6 +27,7 @@ export type Payload<T = any> = {
 export type Next = <T>(payload?: T) => void
 export type Panic = (error: Error) => void
 export type Status = (code: number, message?: string) => void
+export type Empty = (code: number, message?: string) => void
 export type Handler = (context: Context, payload?: any) => any
 export type ErrorHandler = (context: Context, error: Error) => void
 export type Dispatch = (context: Context, payload?: unknown) => void

--- a/packages/wezi/src/index.ts
+++ b/packages/wezi/src/index.ts
@@ -5,11 +5,15 @@ import { shared } from 'wezi-shared'
 import { actions } from 'wezi-actions'
 import { Context, Handler, Status } from 'wezi-types'
 
-const status = (context: Context): Status => (code: number, message?: string) => {
+const status = (context: Context): Status => (code: number, message = ''): void => {
     context.res.statusCode = code
-    if (message) {
-        context.res.statusMessage = message
-    }
+    context.res.statusMessage = message
+}
+
+const empty = (context: Context) => (code: number, message = ''): void => {
+    context.res.statusCode = code
+    context.res.statusMessage = message
+    context.res.end(null, null, null)
 }
 
 const createContext = (req: IncomingMessage, res: ServerResponse): Context => {
@@ -19,6 +23,7 @@ const createContext = (req: IncomingMessage, res: ServerResponse): Context => {
         , body: null
         , next: null
         , panic: null
+        , empty: null
         , status: null
         , shared: null
         , actions: null
@@ -29,6 +34,7 @@ const createEnhancedContext = (context: Context): Context => {
     return {
         ...context
         , body: body(context)
+        , empty: empty(context)
         , status: status(context)
         , shared: shared(context)
         , actions: actions(context)

--- a/tests/wezi.test.ts
+++ b/tests/wezi.test.ts
@@ -114,3 +114,23 @@ test('context set response status code whitout message', async (t) => {
     t.is(res.status, 300)
     t.is(res.statusText, 'Multiple Choices')
 })
+
+test('context send empty whitout message', async (t) => {
+    const handler = ({ empty }: Context) => empty(300)
+
+    const url = await server(handler)
+    const res = await fetch(url)
+
+    t.is(res.status, 300)
+    t.is(res.statusText, 'Multiple Choices')
+})
+
+test('context send empty whit message', async (t) => {
+    const handler = ({ empty }: Context) => empty(300, 'Cool')
+
+    const url = await server(handler)
+    const res = await fetch(url)
+
+    t.is(res.status, 300)
+    t.is(res.statusText, 'Cool')
+})


### PR DESCRIPTION
This must be used to send empty response with status code, without body.

```ts
const handler = ({ empty }) => empty(300)
listen(wezi(handler))
```