### PR TITLE
reat: add querystring opt-in support

### DIFF
--- a/packages/querystring/.eslintrc
+++ b/packages/querystring/.eslintrc
@@ -1,0 +1,3 @@
+{
+    "extends": "../../.eslintrc"
+}

--- a/packages/querystring/.npmignore
+++ b/packages/querystring/.npmignore
@@ -1,0 +1,7 @@
+*.build.tsbuildinfo
+.eslintrc
+.vscode
+tsconfig.build.json
+tsconfig.json
+test
+dev

--- a/packages/querystring/index.ts
+++ b/packages/querystring/index.ts
@@ -1,0 +1,4 @@
+import { queryParser } from './src'
+export * from './src'
+export default queryParser
+

--- a/packages/querystring/package.json
+++ b/packages/querystring/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "wezi-query",
+    "version": "1.0.0-alpha.17",
+    "description": "wezi querystring parser",
+    "main": "dist/index.js",
+    "types": "index.ts",
+    "license": "MIT",
+    "author": {
+        "name": "Horacio Rivero",
+        "email": "horacioriverods@gmail.com"
+    },
+    "scripts": {
+        "build": "yarn run clean && yarn run compile",
+        "clean": "rm -rf ./dist && rm -rf ./node_modules/.cache",
+        "compile": "rollup -c",
+        "prepublishOnly": "yarn run build"
+    },
+    "dependencies": {
+        "wezi-types": "^1.0.0-alpha.17"
+    },
+    "type": "module"
+}

--- a/packages/querystring/rollup.config.js
+++ b/packages/querystring/rollup.config.js
@@ -1,0 +1,6 @@
+import config from '../../build/builder'
+import { dependencies } from './package.json'
+
+export default config({
+    external: dependencies
+})

--- a/packages/querystring/src/index.ts
+++ b/packages/querystring/src/index.ts
@@ -1,0 +1,32 @@
+import { Context } from 'wezi-types'
+import querystring from 'querystring'
+
+export type Payload<P = void, Q = void> = {
+    query: Q
+    params: P
+}
+
+type Dictionary = {
+    [key: string]: string
+}
+
+const getQuery = (url: string, idx: number) => {
+    const search = url.substring(idx)
+    const path = search.substring(1)
+    const query = querystring.parse(path)
+    return query
+}
+
+const getQueryString = (url: string) => {
+    const index = url.indexOf('?', 1)
+    if (index !== -1) return getQuery(url, index)
+    return null
+}
+
+export const queryParser = (context: Context, params: Dictionary) => {
+    const query = getQueryString(context.req.url)
+    context.next({
+        params
+        , query
+    })
+}

--- a/packages/querystring/tsconfig.json
+++ b/packages/querystring/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.build.json"
+}

--- a/tests/querystring.test.ts
+++ b/tests/querystring.test.ts
@@ -1,0 +1,40 @@
+import test from 'ava'
+import fetch from 'node-fetch'
+import router, { get } from 'wezi-router'
+import queryParser, { Payload } from 'wezi-query'
+import { server } from './helpers'
+
+test('get query string params', async (t) => {
+    type Query = {
+        name: string
+        surname: string
+    }
+
+    const greet = (_c, { query }: Payload<void, Query>) => `${query.name} ${query.surname}`
+    const r = router()
+    const url = await server(r(get('/users', queryParser, greet)))
+    const res = await fetch(`${url}/users?name=foo&surname=bar`)
+    const body = await res.text()
+
+    t.is(body, 'foo bar')
+})
+
+test('get query string params whit router params', async (t) => {
+    type Params = {
+        id: string
+    }
+
+    type Query = {
+        name: string
+        surname: string
+    }
+
+    const greet = (_c, { params, query }: Payload<Params, Query>) => `${params.id} ${query.name} ${query.surname}`
+    const r = router()
+    const url = await server(r(get('/users/:id', queryParser, greet)))
+    const res = await fetch(`${url}/users/12?name=foo&surname=bar`)
+    const body = await res.text()
+
+    t.is(body, '12 foo bar')
+})
+

--- a/tests/querystring.test.ts
+++ b/tests/querystring.test.ts
@@ -38,3 +38,16 @@ test('get query string params whit router params', async (t) => {
     t.is(body, '12 foo bar')
 })
 
+test('get query string params must be null', async (t) => {
+    type Query = {
+        name: string
+    }
+
+    const greet = (_c, { query }: Payload<void, Query>) => query === null ? 'is null' : 'not is null value'
+    const r = router()
+    const url = await server(r(get('/users', queryParser, greet)))
+    const res = await fetch(`${url}/users`)
+    const body = await res.text()
+
+    t.is(body, 'is null')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
       "wezi-error": [
         "packages/error"
       ],
+      "wezi-query": [
+        "packages/querystring"
+      ],
       "wezi-receive": [
         "packages/receive"
       ],


### PR DESCRIPTION
```ts

import wezi, { listen } from 'wezi'
import query, { Payload } from 'wezi-query'
import router, { get } from 'wezi-router'

type Params = {
    id: string
}

type Query = {
    foo: string
}

const getUser = (_c, payload: Payload<Params, Query>) => {
    return payload.query.foo + payload.params.id
}

const r = router()
const routes = r(
    get('/users/:id', query, getUser)
)

listen(wezi(routes))