### PR TITLE
feat: export fn to create custom route entities

### DIFF
--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -8,6 +8,7 @@ export {
     , patch
     , options
     , route
+    , createRouteEntity
 } from './src/router'
 
 export default createRouter

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -42,7 +42,7 @@ const prepareRoutes = (matcher: Matcher, entities: RouteEntity[], prepareCompose
     return matchRoute(matcher)
 }
 
-const createRouteEntity = (method: string) => (pathOrHandler: string | Handler, ...handlers: Handler[]): RouteEntity => {
+export const createRouteEntity = (method: string) => (pathOrHandler: string | Handler, ...handlers: Handler[]): RouteEntity => {
     if (typeof pathOrHandler === 'function') {
         return {
             path: ''


### PR DESCRIPTION
Now the router provides the functionality to create custom route entities.

```ts
import  { createRouteEntity } from 'wezi-router'

const foo = (c: Context) => text(c, 'Foo')
const trace = createRouteEntity('TRACE')
router(trace('/', foo))
```